### PR TITLE
Fix compilation of Qdatastream (windows, visual 2013)

### DIFF
--- a/src/cookiejar.cpp
+++ b/src/cookiejar.cpp
@@ -35,6 +35,7 @@
 #include <QTimer>
 #include <QDebug>
 #include <QNetworkCookie>
+#include <QDataStream>
 
 #define COOKIE_JAR_VERSION      1
 


### PR DESCRIPTION
This is a simple compilation fix. Application would not compile with Qt5, Visual 2013 on windows
